### PR TITLE
Split EnsemblFetcher into multiple classes

### DIFF
--- a/jami-bridges/jami-ensembl/src/main/java/psidev/psi/mi/jami/bridges/ensembl/EnsemblGeneFetcher.java
+++ b/jami-bridges/jami-ensembl/src/main/java/psidev/psi/mi/jami/bridges/ensembl/EnsemblGeneFetcher.java
@@ -1,0 +1,29 @@
+package psidev.psi.mi.jami.bridges.ensembl;
+
+import psidev.psi.mi.jami.bridges.exception.BridgeFailedException;
+import psidev.psi.mi.jami.bridges.fetcher.GeneFetcher;
+import psidev.psi.mi.jami.model.Gene;
+import psidev.psi.mi.jami.model.Interactor;
+
+import java.util.Collection;
+import java.util.Map;
+
+public class EnsemblGeneFetcher extends AbstractEnsemblFetcher<Gene> implements GeneFetcher {
+
+    public EnsemblGeneFetcher() throws BridgeFailedException {
+    }
+
+    protected Gene buildInteractor(String identifier, ApiObject entree, Map<String, Interactor> translationIdToInteractor) {
+        return buildGeneInteractor(identifier, entree, translationIdToInteractor);
+    }
+
+    @Override
+    public Collection<Gene> fetchByIdentifier(String identifier, int taxID) throws BridgeFailedException {
+        return fetchByIdentifier(identifier);
+    }
+
+    @Override
+    public Collection<Gene> fetchByIdentifiers(Collection<String> identifiers, int taxID) throws BridgeFailedException {
+        return fetchByIdentifiers(identifiers);
+    }
+}

--- a/jami-bridges/jami-ensembl/src/main/java/psidev/psi/mi/jami/bridges/ensembl/EnsemblInteractorFetcher.java
+++ b/jami-bridges/jami-ensembl/src/main/java/psidev/psi/mi/jami/bridges/ensembl/EnsemblInteractorFetcher.java
@@ -1,0 +1,26 @@
+package psidev.psi.mi.jami.bridges.ensembl;
+
+import psidev.psi.mi.jami.bridges.exception.BridgeFailedException;
+import psidev.psi.mi.jami.model.*;
+
+import java.util.*;
+
+public class EnsemblInteractorFetcher extends AbstractEnsemblFetcher<Interactor> {
+
+    public EnsemblInteractorFetcher() throws BridgeFailedException {
+    }
+
+    protected Interactor buildInteractor(String identifier, ApiObject entree, Map<String, Interactor> translationIdToInteractor) {
+
+        switch (entree.getObjectType()) {
+            case GENE:
+                return buildGeneInteractor(identifier, entree, translationIdToInteractor);
+            case TRANSCRIPT:
+                return buildNucleicAcid(identifier, entree, translationIdToInteractor);
+            case TRANSLATION:
+            case EXON:
+                break;
+        }
+        return null;
+    }
+}

--- a/jami-bridges/jami-ensembl/src/main/java/psidev/psi/mi/jami/bridges/ensembl/EnsemblNucleicAcidFetcher.java
+++ b/jami-bridges/jami-ensembl/src/main/java/psidev/psi/mi/jami/bridges/ensembl/EnsemblNucleicAcidFetcher.java
@@ -1,0 +1,29 @@
+package psidev.psi.mi.jami.bridges.ensembl;
+
+import psidev.psi.mi.jami.bridges.exception.BridgeFailedException;
+import psidev.psi.mi.jami.bridges.fetcher.NucleicAcidFetcher;
+import psidev.psi.mi.jami.model.Interactor;
+import psidev.psi.mi.jami.model.NucleicAcid;
+
+import java.util.Collection;
+import java.util.Map;
+
+public class EnsemblNucleicAcidFetcher extends AbstractEnsemblFetcher<NucleicAcid> implements NucleicAcidFetcher {
+
+    public EnsemblNucleicAcidFetcher() throws BridgeFailedException {
+    }
+
+    protected NucleicAcid buildInteractor(String identifier, ApiObject entree, Map<String, Interactor> translationIdToInteractor) {
+        return buildNucleicAcid(identifier, entree, translationIdToInteractor);
+    }
+
+    @Override
+    public Collection<NucleicAcid> fetchByIdentifier(String identifier, int taxID) throws BridgeFailedException {
+        return fetchByIdentifier(identifier);
+    }
+
+    @Override
+    public Collection<NucleicAcid> fetchByIdentifiers(Collection<String> identifiers, int taxID) throws BridgeFailedException {
+        return NucleicAcidFetcher.super.fetchByIdentifiers(identifiers, taxID);
+    }
+}

--- a/jami-bridges/jami-ensembl/src/test/java/psidev/psi/mi/jami/bridges/ensembl/EnsemblInteractorFetcherTest.java
+++ b/jami-bridges/jami-ensembl/src/test/java/psidev/psi/mi/jami/bridges/ensembl/EnsemblInteractorFetcherTest.java
@@ -15,13 +15,13 @@ import java.util.Objects;
 
 import static org.junit.Assert.*;
 
-public class EnsemblFetcherTest {
+public class EnsemblInteractorFetcherTest {
 
-    EnsemblFetcher fetcher;
+    EnsemblInteractorFetcher fetcher;
 
     @Before
     public void setUp() throws Exception {
-        fetcher = new EnsemblFetcher();
+        fetcher = new EnsemblInteractorFetcher();
     }
 
     @Test


### PR DESCRIPTION
Split `EnsemblFetcher` into:
- `EnsemblInteractorFetcher`: to be used by the editor
- `EnsemblGeneFetcher`: fetcher that implements `GeneFetcher`
- `EnsemblNucleicAcidFetcher`: fetcher that implements `NucleicAcidFetcher`