### PR TITLE
Ols error handler

### DIFF
--- a/jami-batch/pom.xml
+++ b/jami-batch/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>psidev.psi.mi.jami</groupId>
         <artifactId>psi-jami</artifactId>
-        <version>3.4.0</version>
+        <version>3.4.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>jami-batch</artifactId>

--- a/jami-bridges/bridges-core/pom.xml
+++ b/jami-bridges/bridges-core/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>psidev.psi.mi.jami.bridges</groupId>
         <artifactId>jami-bridges</artifactId>
-        <version>3.4.0</version>
+        <version>3.4.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>bridges-core</artifactId>

--- a/jami-bridges/jami-chebi/pom.xml
+++ b/jami-bridges/jami-chebi/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>psidev.psi.mi.jami.bridges</groupId>
         <artifactId>jami-bridges</artifactId>
-        <version>3.4.0</version>
+        <version>3.4.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>jami-chebi</artifactId>

--- a/jami-bridges/jami-europubmedcentral/pom.xml
+++ b/jami-bridges/jami-europubmedcentral/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>jami-bridges</artifactId>
         <groupId>psidev.psi.mi.jami.bridges</groupId>
-        <version>3.4.0</version>
+        <version>3.4.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>jami-europubmedcentral</artifactId>

--- a/jami-bridges/jami-imexcentral/pom.xml
+++ b/jami-bridges/jami-imexcentral/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>psidev.psi.mi.jami.bridges</groupId>
         <artifactId>jami-bridges</artifactId>
-        <version>3.4.0</version>
+        <version>3.4.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>jami-imexcentral</artifactId>

--- a/jami-bridges/jami-obo/pom.xml
+++ b/jami-bridges/jami-obo/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>psidev.psi.mi.jami.bridges</groupId>
         <artifactId>jami-bridges</artifactId>
-        <version>3.4.0</version>
+        <version>3.4.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>jami-obo</artifactId>

--- a/jami-bridges/jami-ols/pom.xml
+++ b/jami-bridges/jami-ols/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>psidev.psi.mi.jami.bridges</groupId>
         <artifactId>jami-bridges</artifactId>
-        <version>3.4.0</version>
+        <version>3.4.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>jami-ols</artifactId>

--- a/jami-bridges/jami-ols/src/main/java/psidev/psi/mi/jami/bridges/ols/AbstractOlsFetcher.java
+++ b/jami-bridges/jami-ols/src/main/java/psidev/psi/mi/jami/bridges/ols/AbstractOlsFetcher.java
@@ -151,8 +151,18 @@ public abstract class AbstractOlsFetcher<T extends CvTerm> implements CvTermFetc
         if(dbMap.containsKey(miOntologyName))
             olsOntologyName = dbMap.get(miOntologyName).toLowerCase();
 
-        // 1) query ols which returns full name.
-        Term term = olsClient.getExactTermByName(searchName, olsOntologyName);
+        Term term = null;
+        try {
+            // 1) query ols which returns full name.
+            term = olsClient.getExactTermByName(searchName, olsOntologyName);
+        }
+        catch (HttpClientErrorException e){
+            //If the exception is different to 404 (not found) we pass it,
+            // in other case we ignore it a return null
+            if(!HttpStatus.NOT_FOUND.equals(e.getStatusCode())){
+                throw new BridgeFailedException(e);
+            }
+        }
 
         // 2) if no results, return null
         if (term == null) {
@@ -172,8 +182,18 @@ public abstract class AbstractOlsFetcher<T extends CvTerm> implements CvTermFetc
         if(searchName == null || searchName.isEmpty())
             throw new IllegalArgumentException("Can not search for an identifier without a value.");
 
-        // 1) query ols which returns full name.
-        Term term = olsClient.getExactTermByName(searchName, null);
+        Term term = null;
+        try {
+            // 1) query ols which returns full name.
+            term = olsClient.getExactTermByName(searchName, null);
+        }
+        catch (HttpClientErrorException e){
+            //If the exception is different to 404 (not found) we pass it,
+            // in other case we ignore it a return null
+            if(!HttpStatus.NOT_FOUND.equals(e.getStatusCode())){
+                throw new BridgeFailedException(e);
+            }
+        }
 
         // 2) if no results, return null
         if (term == null) {

--- a/jami-bridges/jami-ontology-manager/pom.xml
+++ b/jami-bridges/jami-ontology-manager/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>psidev.psi.mi.jami.bridges</groupId>
         <artifactId>jami-bridges</artifactId>
-        <version>3.4.0</version>
+        <version>3.4.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>jami-ontology-manager</artifactId>

--- a/jami-bridges/jami-uniprot-protein-api/pom.xml
+++ b/jami-bridges/jami-uniprot-protein-api/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>psidev.psi.mi.jami.bridges</groupId>
         <artifactId>jami-bridges</artifactId>
-        <version>3.4.0</version>
+        <version>3.4.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>jami-uniprot-protein-api</artifactId>

--- a/jami-bridges/jami-uniprot-taxonomy/pom.xml
+++ b/jami-bridges/jami-uniprot-taxonomy/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>psidev.psi.mi.jami.bridges</groupId>
         <artifactId>jami-bridges</artifactId>
-        <version>3.4.0</version>
+        <version>3.4.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>jami-uniprot-taxonomy</artifactId>

--- a/jami-bridges/jami-uniprot/pom.xml
+++ b/jami-bridges/jami-uniprot/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>psidev.psi.mi.jami.bridges</groupId>
         <artifactId>jami-bridges</artifactId>
-        <version>3.4.0</version>
+        <version>3.4.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>jami-uniprot</artifactId>

--- a/jami-bridges/jami-unisave/pom.xml
+++ b/jami-bridges/jami-unisave/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>psidev.psi.mi.jami.bridges</groupId>
         <artifactId>jami-bridges</artifactId>
-        <version>3.4.0</version>
+        <version>3.4.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>jami-unisave</artifactId>

--- a/jami-bridges/pom.xml
+++ b/jami-bridges/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>psidev.psi.mi.jami</groupId>
         <artifactId>psi-jami</artifactId>
-        <version>3.4.0</version>
+        <version>3.4.1-SNAPSHOT</version>
     </parent>
 
     <groupId>psidev.psi.mi.jami.bridges</groupId>

--- a/jami-commons/pom.xml
+++ b/jami-commons/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>psidev.psi.mi.jami</groupId>
         <artifactId>psi-jami</artifactId>
-        <version>3.4.0</version>
+        <version>3.4.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>jami-commons</artifactId>

--- a/jami-core/pom.xml
+++ b/jami-core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>psidev.psi.mi.jami</groupId>
         <artifactId>psi-jami</artifactId>
-        <version>3.4.0</version>
+        <version>3.4.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>jami-core</artifactId>

--- a/jami-crosslink-csv/pom.xml
+++ b/jami-crosslink-csv/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>psidev.psi.mi.jami</groupId>
         <artifactId>psi-jami</artifactId>
-        <version>3.4.0</version>
+        <version>3.4.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>jami-crosslink-csv</artifactId>

--- a/jami-enricher/pom.xml
+++ b/jami-enricher/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>psidev.psi.mi.jami</groupId>
         <artifactId>psi-jami</artifactId>
-        <version>3.4.0</version>
+        <version>3.4.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>jami-enricher</artifactId>

--- a/jami-examples/pom.xml
+++ b/jami-examples/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>psidev.psi.mi.jami</groupId>
         <artifactId>psi-jami</artifactId>
-        <version>3.4.0</version>
+        <version>3.4.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>jami-examples</artifactId>

--- a/jami-html/pom.xml
+++ b/jami-html/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>psidev.psi.mi.jami</groupId>
         <artifactId>psi-jami</artifactId>
-        <version>3.4.0</version>
+        <version>3.4.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>jami-html</artifactId>

--- a/jami-imex-updater/pom.xml
+++ b/jami-imex-updater/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>psidev.psi.mi.jami</groupId>
         <artifactId>psi-jami</artifactId>
-        <version>3.4.0</version>
+        <version>3.4.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>jami-imex-updater</artifactId>

--- a/jami-interactionviewer-json/pom.xml
+++ b/jami-interactionviewer-json/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>psidev.psi.mi.jami</groupId>
         <artifactId>psi-jami</artifactId>
-        <version>3.4.0</version>
+        <version>3.4.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>jami-interactionviewer-json</artifactId>

--- a/jami-mitab/pom.xml
+++ b/jami-mitab/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>psidev.psi.mi.jami</groupId>
         <artifactId>psi-jami</artifactId>
-        <version>3.4.0</version>
+        <version>3.4.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>jami-mitab</artifactId>

--- a/jami-xml/pom.xml
+++ b/jami-xml/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>psidev.psi.mi.jami</groupId>
         <artifactId>psi-jami</artifactId>
-        <version>3.4.0</version>
+        <version>3.4.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>jami-xml</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>psidev.psi.mi.jami</groupId>
     <artifactId>psi-jami</artifactId>
-    <version>3.4.0</version>
+    <version>3.4.1-SNAPSHOT</version>
 
     <packaging>pom</packaging>
     <name>PSI :: JAMI - Java framework for molecular interactions</name>


### PR DESCRIPTION
Intact Portal SOLR indexer failed to index an interaction due to a bad request to OLS client.

The interaction has a feature with the charcater β in the name. When OLS is called, it returns a bad request error, and we are not dealing with that error properly. Updating the OLS fetcher to deal with these errors in the same way we already do in the same class, on a different method.