### PR TITLE
Fix enrichers and fetchers for mRNA and miRNA

### DIFF
--- a/jami-batch/pom.xml
+++ b/jami-batch/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>psidev.psi.mi.jami</groupId>
         <artifactId>psi-jami</artifactId>
-        <version>3.5.0</version>
+        <version>3.5.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>jami-batch</artifactId>

--- a/jami-bridges/bridges-core/pom.xml
+++ b/jami-bridges/bridges-core/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>psidev.psi.mi.jami.bridges</groupId>
         <artifactId>jami-bridges</artifactId>
-        <version>3.5.0</version>
+        <version>3.5.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>bridges-core</artifactId>

--- a/jami-bridges/jami-chebi/pom.xml
+++ b/jami-bridges/jami-chebi/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>psidev.psi.mi.jami.bridges</groupId>
         <artifactId>jami-bridges</artifactId>
-        <version>3.5.0</version>
+        <version>3.5.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>jami-chebi</artifactId>

--- a/jami-bridges/jami-ensembl/pom.xml
+++ b/jami-bridges/jami-ensembl/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>psidev.psi.mi.jami.bridges</groupId>
         <artifactId>jami-bridges</artifactId>
-        <version>3.5.0</version>
+        <version>3.5.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>jami-ensembl</artifactId>

--- a/jami-bridges/jami-europubmedcentral/pom.xml
+++ b/jami-bridges/jami-europubmedcentral/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>jami-bridges</artifactId>
         <groupId>psidev.psi.mi.jami.bridges</groupId>
-        <version>3.5.0</version>
+        <version>3.5.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>jami-europubmedcentral</artifactId>

--- a/jami-bridges/jami-imexcentral/pom.xml
+++ b/jami-bridges/jami-imexcentral/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>psidev.psi.mi.jami.bridges</groupId>
         <artifactId>jami-bridges</artifactId>
-        <version>3.5.0</version>
+        <version>3.5.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>jami-imexcentral</artifactId>

--- a/jami-bridges/jami-obo/pom.xml
+++ b/jami-bridges/jami-obo/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>psidev.psi.mi.jami.bridges</groupId>
         <artifactId>jami-bridges</artifactId>
-        <version>3.5.0</version>
+        <version>3.5.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>jami-obo</artifactId>

--- a/jami-bridges/jami-ols/pom.xml
+++ b/jami-bridges/jami-ols/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>psidev.psi.mi.jami.bridges</groupId>
         <artifactId>jami-bridges</artifactId>
-        <version>3.5.0</version>
+        <version>3.5.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>jami-ols</artifactId>

--- a/jami-bridges/jami-ontology-manager/pom.xml
+++ b/jami-bridges/jami-ontology-manager/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>psidev.psi.mi.jami.bridges</groupId>
         <artifactId>jami-bridges</artifactId>
-        <version>3.5.0</version>
+        <version>3.5.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>jami-ontology-manager</artifactId>

--- a/jami-bridges/jami-rna-central/pom.xml
+++ b/jami-bridges/jami-rna-central/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>psidev.psi.mi.jami.bridges</groupId>
         <artifactId>jami-bridges</artifactId>
-        <version>3.5.0</version>
+        <version>3.5.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>jami-rna-central</artifactId>

--- a/jami-bridges/jami-rna-central/src/main/java/psidev/psi/mi/jami/bridges/rna/central/RNACentralFetcher.java
+++ b/jami-bridges/jami-rna-central/src/main/java/psidev/psi/mi/jami/bridges/rna/central/RNACentralFetcher.java
@@ -11,6 +11,7 @@ import psidev.psi.mi.jami.model.NucleicAcid;
 import psidev.psi.mi.jami.model.Organism;
 import psidev.psi.mi.jami.model.Xref;
 import psidev.psi.mi.jami.model.impl.*;
+import psidev.psi.mi.jami.utils.XrefUtils;
 
 import java.io.IOException;
 import java.net.URL;
@@ -88,6 +89,7 @@ public class RNACentralFetcher implements NucleicAcidFetcher {
 
     private void extractXrefsAndAliases(NucleicAcid nucleicAcid, ApiXrefs.Result result) {
         Collection<Xref> xrefs = nucleicAcid.getXrefs();
+        Collection<Xref> identifiers = nucleicAcid.getIdentifiers();
 
         XrefType xrefType = XrefType.getByDatabase(result.getDatabase());
 
@@ -100,7 +102,13 @@ public class RNACentralFetcher implements NucleicAcidFetcher {
                     .map(PartialCvTerm::complete)
                     .findFirst().orElse(OLSUtils.secondaryAcCV);
 
-            xrefs.add(new DefaultXref(database, result.getAccession().getExternalId(), qualifier));
+            Xref newXref = new DefaultXref(database, result.getAccession().getExternalId(), qualifier);
+
+            if (XrefUtils.isXrefAnIdentifier(newXref)) {
+                identifiers.add(newXref);
+            } else {
+                xrefs.add(newXref);
+            }
 
             xrefType.extraReferenceBuilders.stream()
                     .map(builder -> builder.apply(result))
@@ -108,7 +116,13 @@ public class RNACentralFetcher implements NucleicAcidFetcher {
                             PartialXref.builder()
                                     .database(PartialCvTerm.from(database))
                                     .build()))
-                    .forEach(xrefs::add);
+                    .forEach(xref -> {
+                        if (XrefUtils.isXrefAnIdentifier(xref)) {
+                            identifiers.add(xref);
+                        } else {
+                            xrefs.add(xref);
+                        }
+                    });
         }
 
         xrefType.aliasBuilders.stream()

--- a/jami-bridges/jami-uniprot-protein-api/pom.xml
+++ b/jami-bridges/jami-uniprot-protein-api/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>psidev.psi.mi.jami.bridges</groupId>
         <artifactId>jami-bridges</artifactId>
-        <version>3.5.0</version>
+        <version>3.5.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>jami-uniprot-protein-api</artifactId>

--- a/jami-bridges/jami-uniprot-taxonomy/pom.xml
+++ b/jami-bridges/jami-uniprot-taxonomy/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>psidev.psi.mi.jami.bridges</groupId>
         <artifactId>jami-bridges</artifactId>
-        <version>3.5.0</version>
+        <version>3.5.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>jami-uniprot-taxonomy</artifactId>

--- a/jami-bridges/jami-uniprot/pom.xml
+++ b/jami-bridges/jami-uniprot/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>psidev.psi.mi.jami.bridges</groupId>
         <artifactId>jami-bridges</artifactId>
-        <version>3.5.0</version>
+        <version>3.5.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>jami-uniprot</artifactId>

--- a/jami-bridges/jami-unisave/pom.xml
+++ b/jami-bridges/jami-unisave/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>psidev.psi.mi.jami.bridges</groupId>
         <artifactId>jami-bridges</artifactId>
-        <version>3.5.0</version>
+        <version>3.5.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>jami-unisave</artifactId>

--- a/jami-bridges/pom.xml
+++ b/jami-bridges/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>psidev.psi.mi.jami</groupId>
         <artifactId>psi-jami</artifactId>
-        <version>3.5.0</version>
+        <version>3.5.1-SNAPSHOT</version>
     </parent>
 
     <groupId>psidev.psi.mi.jami.bridges</groupId>

--- a/jami-commons/pom.xml
+++ b/jami-commons/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>psidev.psi.mi.jami</groupId>
         <artifactId>psi-jami</artifactId>
-        <version>3.5.0</version>
+        <version>3.5.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>jami-commons</artifactId>

--- a/jami-core/pom.xml
+++ b/jami-core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>psidev.psi.mi.jami</groupId>
         <artifactId>psi-jami</artifactId>
-        <version>3.5.0</version>
+        <version>3.5.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>jami-core</artifactId>

--- a/jami-core/src/main/java/psidev/psi/mi/jami/model/NucleicAcid.java
+++ b/jami-core/src/main/java/psidev/psi/mi/jami/model/NucleicAcid.java
@@ -13,6 +13,10 @@ public interface NucleicAcid extends Polymer {
     public static final String NULCEIC_ACID="nucleic acid";
     /** Constant <code>NULCEIC_ACID_MI="MI:0318"</code> */
     public static final String NULCEIC_ACID_MI="MI:0318";
+    public static final String MRNA = "mrna";
+    public static final String MRNA_MI = "MI:0324";
+    public static final String MIRNA = "mirna";
+    public static final String MIRNA_MI = "MI:2204";
 
     /**
      * The unique DDBJ/EMBL/GemBank identifier which identifies the nucleic acid.

--- a/jami-core/src/main/resources/interactorDatabase.properties
+++ b/jami-core/src/main/resources/interactorDatabase.properties
@@ -55,3 +55,4 @@ MI\:0485(uniparc)=protein
 MI\:0486(uniprotkb)=protein
 MI\:1098(swiss-prot)=protein
 MI\:1099(trembl)=protein
+MI\:1357(rnacentral)=nucleic_acid

--- a/jami-core/src/main/resources/interactorType.properties
+++ b/jami-core/src/main/resources/interactorType.properties
@@ -36,3 +36,4 @@ MI\:1304(molecule\ set)=interactor_set
 MI\:1305(candidate\ set)=interactor_set
 MI\:1307(defined\ set)=interactor_set
 MI\:1306(open\ set)=interactor_set
+MI\:2204(mirna)=nucleic_acid

--- a/jami-crosslink-csv/pom.xml
+++ b/jami-crosslink-csv/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>psidev.psi.mi.jami</groupId>
         <artifactId>psi-jami</artifactId>
-        <version>3.5.0</version>
+        <version>3.5.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>jami-crosslink-csv</artifactId>

--- a/jami-enricher/pom.xml
+++ b/jami-enricher/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>psidev.psi.mi.jami</groupId>
         <artifactId>psi-jami</artifactId>
-        <version>3.5.0</version>
+        <version>3.5.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>jami-enricher</artifactId>

--- a/jami-enricher/src/main/java/psidev/psi/mi/jami/enricher/impl/CompositeInteractorEnricher.java
+++ b/jami-enricher/src/main/java/psidev/psi/mi/jami/enricher/impl/CompositeInteractorEnricher.java
@@ -176,6 +176,8 @@ public class CompositeInteractorEnricher implements InteractorEnricher<Interacto
         if (object instanceof Polymer) {
             if (object instanceof Protein && this.proteinEnricher != null) {
                 this.proteinEnricher.enrich((Protein) object);
+            } else if (object instanceof NucleicAcid && this.nucleicAcidEnricher != null) {
+                this.nucleicAcidEnricher.enrich((NucleicAcid) object);
             } else if (this.polymerBaseEnricher != null) {
                 this.polymerBaseEnricher.enrich((Polymer) object);
             } else {
@@ -183,8 +185,6 @@ public class CompositeInteractorEnricher implements InteractorEnricher<Interacto
             }
         } else if (object instanceof Gene && this.geneEnricher != null) {
             this.geneEnricher.enrich((Gene) object);
-        } else if (object instanceof NucleicAcid && this.nucleicAcidEnricher != null) {
-            this.nucleicAcidEnricher.enrich((NucleicAcid) object);
         } else if (object instanceof BioactiveEntity && this.bioactiveEntityEnricher != null) {
             this.bioactiveEntityEnricher.enrich((BioactiveEntity) object);
         } else if (object instanceof Complex && this.complexEnricher != null) {
@@ -222,6 +222,8 @@ public class CompositeInteractorEnricher implements InteractorEnricher<Interacto
         if (object instanceof Polymer && objectSource instanceof Polymer) {
             if (object instanceof Protein && objectSource instanceof Protein && this.proteinEnricher != null) {
                 this.proteinEnricher.enrich((Protein) object, (Protein) objectSource);
+            } else if (object instanceof NucleicAcid && objectSource instanceof NucleicAcid && this.nucleicAcidEnricher != null) {
+                this.nucleicAcidEnricher.enrich((NucleicAcid) object, (NucleicAcid) objectSource);
             } else if (this.polymerBaseEnricher != null) {
                 this.polymerBaseEnricher.enrich((Polymer) object, (Polymer) objectSource);
             } else {
@@ -306,6 +308,9 @@ public class CompositeInteractorEnricher implements InteractorEnricher<Interacto
         if (getInteractorPoolEnricher() != null) {
             getInteractorPoolEnricher().setCvTermEnricher(enricher);
         }
+        if (getNucleicAcidEnricher() != null) {
+            getNucleicAcidEnricher().setCvTermEnricher(enricher);
+        }
     }
 
     /**
@@ -330,6 +335,9 @@ public class CompositeInteractorEnricher implements InteractorEnricher<Interacto
         }
         if (getInteractorPoolEnricher() != null) {
             getInteractorPoolEnricher().setOrganismEnricher(enricher);
+        }
+        if (getNucleicAcidEnricher() != null) {
+            getNucleicAcidEnricher().setOrganismEnricher(enricher);
         }
     }
 }

--- a/jami-enricher/src/main/java/psidev/psi/mi/jami/enricher/impl/full/FullNucleicAcidEnricher.java
+++ b/jami-enricher/src/main/java/psidev/psi/mi/jami/enricher/impl/full/FullNucleicAcidEnricher.java
@@ -2,12 +2,9 @@ package psidev.psi.mi.jami.enricher.impl.full;
 
 import psidev.psi.mi.jami.bridges.fetcher.GeneFetcher;
 import psidev.psi.mi.jami.bridges.fetcher.NucleicAcidFetcher;
-import psidev.psi.mi.jami.enricher.impl.minimal.MinimalGeneEnricher;
 import psidev.psi.mi.jami.enricher.impl.minimal.MinimalNucleicAcidEnricher;
 import psidev.psi.mi.jami.enricher.listener.NucleicAcidEnricherListener;
-import psidev.psi.mi.jami.enricher.listener.ProteinEnricherListener;
 import psidev.psi.mi.jami.model.NucleicAcid;
-import psidev.psi.mi.jami.model.Protein;
 
 /**
  * A full enricher for genes.

--- a/jami-enricher/src/main/java/psidev/psi/mi/jami/enricher/impl/full/FullNucleicAcidUpdater.java
+++ b/jami-enricher/src/main/java/psidev/psi/mi/jami/enricher/impl/full/FullNucleicAcidUpdater.java
@@ -2,12 +2,9 @@ package psidev.psi.mi.jami.enricher.impl.full;
 
 import psidev.psi.mi.jami.bridges.fetcher.GeneFetcher;
 import psidev.psi.mi.jami.bridges.fetcher.NucleicAcidFetcher;
-import psidev.psi.mi.jami.enricher.impl.minimal.MinimalGeneUpdater;
 import psidev.psi.mi.jami.enricher.impl.minimal.MinimalNucleicAcidUpdater;
 import psidev.psi.mi.jami.enricher.listener.NucleicAcidEnricherListener;
-import psidev.psi.mi.jami.enricher.listener.ProteinEnricherListener;
 import psidev.psi.mi.jami.model.NucleicAcid;
-import psidev.psi.mi.jami.model.Protein;
 
 /**
  * A full updater for genes.

--- a/jami-enricher/src/main/java/psidev/psi/mi/jami/enricher/impl/minimal/MinimalNucleicAcidEnricher.java
+++ b/jami-enricher/src/main/java/psidev/psi/mi/jami/enricher/impl/minimal/MinimalNucleicAcidEnricher.java
@@ -124,6 +124,8 @@ public class MinimalNucleicAcidEnricher extends AbstractInteractorEnricher<Nucle
         // if the interactor type is not a valid bioactive entity interactor type, we cannot enrich
         if (entityToEnrich.getInteractorType() != null &&
                 !CvTermUtils.isCvTerm(entityToEnrich.getInteractorType(), NucleicAcid.NULCEIC_ACID_MI, NucleicAcid.NULCEIC_ACID)
+                && !CvTermUtils.isCvTerm(entityToEnrich.getInteractorType(), NucleicAcid.MRNA_MI, NucleicAcid.MRNA)
+                && !CvTermUtils.isCvTerm(entityToEnrich.getInteractorType(), NucleicAcid.MIRNA_MI, NucleicAcid.MIRNA)
                 && !CvTermUtils.isCvTerm(entityToEnrich.getInteractorType(), Interactor.UNKNOWN_INTERACTOR_MI, Interactor.UNKNOWN_INTERACTOR)) {
             return false;
         }

--- a/jami-examples/pom.xml
+++ b/jami-examples/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>psidev.psi.mi.jami</groupId>
         <artifactId>psi-jami</artifactId>
-        <version>3.5.0</version>
+        <version>3.5.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>jami-examples</artifactId>

--- a/jami-html/pom.xml
+++ b/jami-html/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>psidev.psi.mi.jami</groupId>
         <artifactId>psi-jami</artifactId>
-        <version>3.5.0</version>
+        <version>3.5.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>jami-html</artifactId>

--- a/jami-imex-updater/pom.xml
+++ b/jami-imex-updater/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>psidev.psi.mi.jami</groupId>
         <artifactId>psi-jami</artifactId>
-        <version>3.5.0</version>
+        <version>3.5.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>jami-imex-updater</artifactId>

--- a/jami-interactionviewer-json/pom.xml
+++ b/jami-interactionviewer-json/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>psidev.psi.mi.jami</groupId>
         <artifactId>psi-jami</artifactId>
-        <version>3.5.0</version>
+        <version>3.5.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>jami-interactionviewer-json</artifactId>

--- a/jami-mitab/pom.xml
+++ b/jami-mitab/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>psidev.psi.mi.jami</groupId>
         <artifactId>psi-jami</artifactId>
-        <version>3.5.0</version>
+        <version>3.5.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>jami-mitab</artifactId>

--- a/jami-xml/pom.xml
+++ b/jami-xml/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>psidev.psi.mi.jami</groupId>
         <artifactId>psi-jami</artifactId>
-        <version>3.5.0</version>
+        <version>3.5.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>jami-xml</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>psidev.psi.mi.jami</groupId>
     <artifactId>psi-jami</artifactId>
-    <version>3.5.0</version>
+    <version>3.5.1-SNAPSHOT</version>
 
     <packaging>pom</packaging>
     <name>PSI :: JAMI - Java framework for molecular interactions</name>


### PR DESCRIPTION
A few changes here:
- `interactorDatabase.properties` updated with new rnacentral DB
- `interactorType.properties` updated with new mirna interactor type
- Fix `RNACentralFetcher.java` to create xrefs and identifiers properly. It was setting some identifiers as xrefs which then caused issues on import
- Fix order of which enricher to use in`CompositeInteractorEnricher.java`