### PR TITLE
Psi jami fixes

### DIFF
--- a/jami-batch/pom.xml
+++ b/jami-batch/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>psidev.psi.mi.jami</groupId>
         <artifactId>psi-jami</artifactId>
-        <version>3.5.1-SNAPSHOT</version>
+        <version>3.5.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>jami-batch</artifactId>

--- a/jami-bridges/bridges-core/pom.xml
+++ b/jami-bridges/bridges-core/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>psidev.psi.mi.jami.bridges</groupId>
         <artifactId>jami-bridges</artifactId>
-        <version>3.5.1-SNAPSHOT</version>
+        <version>3.5.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>bridges-core</artifactId>

--- a/jami-bridges/jami-chebi/pom.xml
+++ b/jami-bridges/jami-chebi/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>psidev.psi.mi.jami.bridges</groupId>
         <artifactId>jami-bridges</artifactId>
-        <version>3.5.1-SNAPSHOT</version>
+        <version>3.5.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>jami-chebi</artifactId>

--- a/jami-bridges/jami-ensembl/pom.xml
+++ b/jami-bridges/jami-ensembl/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>psidev.psi.mi.jami.bridges</groupId>
         <artifactId>jami-bridges</artifactId>
-        <version>3.5.1-SNAPSHOT</version>
+        <version>3.5.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>jami-ensembl</artifactId>

--- a/jami-bridges/jami-europubmedcentral/pom.xml
+++ b/jami-bridges/jami-europubmedcentral/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>jami-bridges</artifactId>
         <groupId>psidev.psi.mi.jami.bridges</groupId>
-        <version>3.5.1-SNAPSHOT</version>
+        <version>3.5.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>jami-europubmedcentral</artifactId>

--- a/jami-bridges/jami-imexcentral/pom.xml
+++ b/jami-bridges/jami-imexcentral/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>psidev.psi.mi.jami.bridges</groupId>
         <artifactId>jami-bridges</artifactId>
-        <version>3.5.1-SNAPSHOT</version>
+        <version>3.5.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>jami-imexcentral</artifactId>

--- a/jami-bridges/jami-obo/pom.xml
+++ b/jami-bridges/jami-obo/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>psidev.psi.mi.jami.bridges</groupId>
         <artifactId>jami-bridges</artifactId>
-        <version>3.5.1-SNAPSHOT</version>
+        <version>3.5.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>jami-obo</artifactId>

--- a/jami-bridges/jami-ols/pom.xml
+++ b/jami-bridges/jami-ols/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>psidev.psi.mi.jami.bridges</groupId>
         <artifactId>jami-bridges</artifactId>
-        <version>3.5.1-SNAPSHOT</version>
+        <version>3.5.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>jami-ols</artifactId>

--- a/jami-bridges/jami-ontology-manager/pom.xml
+++ b/jami-bridges/jami-ontology-manager/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>psidev.psi.mi.jami.bridges</groupId>
         <artifactId>jami-bridges</artifactId>
-        <version>3.5.1-SNAPSHOT</version>
+        <version>3.5.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>jami-ontology-manager</artifactId>

--- a/jami-bridges/jami-rna-central/pom.xml
+++ b/jami-bridges/jami-rna-central/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>psidev.psi.mi.jami.bridges</groupId>
         <artifactId>jami-bridges</artifactId>
-        <version>3.5.1-SNAPSHOT</version>
+        <version>3.5.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>jami-rna-central</artifactId>

--- a/jami-bridges/jami-uniprot-protein-api/pom.xml
+++ b/jami-bridges/jami-uniprot-protein-api/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>psidev.psi.mi.jami.bridges</groupId>
         <artifactId>jami-bridges</artifactId>
-        <version>3.5.1-SNAPSHOT</version>
+        <version>3.5.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>jami-uniprot-protein-api</artifactId>

--- a/jami-bridges/jami-uniprot-taxonomy/pom.xml
+++ b/jami-bridges/jami-uniprot-taxonomy/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>psidev.psi.mi.jami.bridges</groupId>
         <artifactId>jami-bridges</artifactId>
-        <version>3.5.1-SNAPSHOT</version>
+        <version>3.5.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>jami-uniprot-taxonomy</artifactId>

--- a/jami-bridges/jami-uniprot/pom.xml
+++ b/jami-bridges/jami-uniprot/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>psidev.psi.mi.jami.bridges</groupId>
         <artifactId>jami-bridges</artifactId>
-        <version>3.5.1-SNAPSHOT</version>
+        <version>3.5.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>jami-uniprot</artifactId>

--- a/jami-bridges/jami-unisave/pom.xml
+++ b/jami-bridges/jami-unisave/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>psidev.psi.mi.jami.bridges</groupId>
         <artifactId>jami-bridges</artifactId>
-        <version>3.5.1-SNAPSHOT</version>
+        <version>3.5.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>jami-unisave</artifactId>

--- a/jami-bridges/jami-unisave/src/main/java/psidev/psi/mi/jami/bridges/unisave/UnisaveClient.java
+++ b/jami-bridges/jami-unisave/src/main/java/psidev/psi/mi/jami/bridges/unisave/UnisaveClient.java
@@ -15,6 +15,7 @@ import psidev.psi.mi.jami.bridges.fetcher.SequenceVersionFetcher;
 
 import java.io.BufferedReader;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.text.DateFormat;
 import java.text.ParseException;
@@ -32,7 +33,7 @@ public class UnisaveClient implements SequenceVersionFetcher{
 
     private static final Log log = LogFactory.getLog(UnisaveClient.class);
 
-    private String unisaveUrlRestJson = "http://www.ebi.ac.uk/uniprot/unisave/rest";
+    private static final String UNISAVE_URL_REST_JSON = "https://rest.uniprot.org/unisave/";
     private HttpClient httpClient;
     private int connectionTimeOut = 20;
     private int socketTimeout = 20;
@@ -44,91 +45,96 @@ public class UnisaveClient implements SequenceVersionFetcher{
 
     }
 
-    private Object getDataFromWebService(String query) throws BridgeFailedException{
+    private Object getJsonDataFromWebService(String query) throws BridgeFailedException{
+        BufferedReader reader = new BufferedReader(new InputStreamReader(this.getDataFromWebService(query)));
+        Object obj = JSONValue.parse(reader);
+        try {
+            reader.close();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+        return obj;
+    }
+
+    private FastaSequence getFastaDataFromWebService(String query) throws BridgeFailedException{
+        BufferedReader reader = new BufferedReader(new InputStreamReader(this.getDataFromWebService(query)));
+        try {
+            return readFastaSequence(reader);
+        } catch (IOException e) {
+            e.printStackTrace();
+        } finally {
+            try {
+                reader.close();
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        }
+        return null;
+    }
+
+    private FastaSequence readFastaSequence(BufferedReader fastaReader) throws IOException {
+
+        // read identifier
+        String lastLine = fastaReader.readLine();
+
+        if (lastLine != null && !lastLine.startsWith(">")){
+            while (lastLine != null && !lastLine.startsWith(">")){
+                lastLine = fastaReader.readLine();
+            }
+        }
+
+        if (lastLine == null){
+            return null;
+        }
+
+        String identifier = lastLine.substring(Math.min(lastLine.length()-1,lastLine.indexOf(">")+1));
+        StringBuilder sequenceBuffer = new StringBuilder();
+
+        // read sequence
+        lastLine = fastaReader.readLine();
+        while (lastLine != null && !lastLine.startsWith(">")){
+
+            sequenceBuffer.append(lastLine.replaceAll("\n",""));
+            lastLine = fastaReader.readLine();
+        }
+
+        if (sequenceBuffer.length() == 0){
+            return null;
+        }
+
+        return new FastaSequence(identifier, sequenceBuffer.toString());
+    }
+
+    private InputStream getDataFromWebService(String query) throws BridgeFailedException{
         HttpGet request = new HttpGet(query);
         request.addHeader("accept", "application/json");
-        BufferedReader reader=null;
-        Object obj=null;
         try {
             HttpResponse response = getHttpClient().execute(request);
             if (response.getStatusLine().getStatusCode() != 200) {
                 throw new BridgeFailedException("Failed to query unisave : HTTP error code : " + response.getStatusLine().getStatusCode());
             }
-            reader = new BufferedReader(new InputStreamReader((response.getEntity().getContent())));
-            obj = JSONValue.parse(reader);
-
+            return response.getEntity().getContent();
         } catch (IOException e) {
             throw new BridgeFailedException("Failed to query unisave", e);
         }
-        finally {
-            if (reader != null){
-                try {
-                    reader.close();
-                } catch (IOException e) {
-                    e.printStackTrace();
-                }
-            }
-        }
-        return obj;
     }
 
-    private String buildQuery(Type type, String id, String version) throws BridgeFailedException {
-        StringBuilder builder = new StringBuilder().append(this.unisaveUrlRestJson);
-        switch (type){
-            case ENTRIES:
-                builder.append(Type.ENTRIES.valueOf()).append(id);
-                break;
-            case ENTRY_VERSION:
-                if(version != null){
-                    builder.append(Type.ENTRY_VERSION.valueOf()).append(id).append("/").append(version);
-                }
-                else {
-                    throw new BridgeFailedException("To use the " + Type.ENTRY_VERSION.valueOf() +
-                            " method in the Rest you have to provide a not null version");
-                }
-                break;
-            case ENTRIES_INFO:
-                builder.append(Type.ENTRIES_INFO.valueOf()).append(id);
-                break;
-            case ENTRY_INFO_VERSION:
-                if (version != null){
-                    builder.append(Type.ENTRY_INFO_VERSION.valueOf()).append(id).append("/").append(version);
-                }
-                else {
-                    throw new BridgeFailedException("To use the " + Type.ENTRY_INFO_VERSION.valueOf() +
-                            " method in the Rest you have to provide a not null version");
-                }
-                break;
-            default:
-                return null;
-        }
-        return builder.toString();
+    private String buildJsonQuery(String id) {
+        return UNISAVE_URL_REST_JSON + id + ".json";
     }
 
-    private String getSequence(String content) {
-        content = content.substring(content.lastIndexOf("SEQUENCE"));
-        content = content.substring(content.indexOf("\n")).trim();
-        content = content.replaceAll(" ", "");
-        content = content.replaceAll("\n", "");
-        return content.replaceAll("\t", "").replaceAll("//", "");
+    private String buildFastaQuery(String id, String version) {
+        return UNISAVE_URL_REST_JSON + id + ".fasta?versions=" + version;
     }
 
-
-    private String getFastHeader(String content) {
-        int init = content.indexOf("FT ");
-        int last = content.lastIndexOf("FT ");
-        if(init == -1) return null;
-        last = content.indexOf("\n", last); //real last
-        return content.substring(init, last);
-    }
-
-    private String getContentForSequenceVersion(String identifier, int sequence_version) throws BridgeFailedException {
-        JSONArray array = (JSONArray) getDataFromWebService(buildQuery(Type.ENTRIES, identifier, null));
-        JSONObject jo = null;
-        for(int i = 0; i < array.size(); ++i){
-            jo = (JSONObject) array.get(i);
-            if (sequence_version == Integer.valueOf(String.valueOf(jo.get("sequence_version")))){
-                return (String)jo.get("content");
+    private FastaSequence getFastaSequenceForSequenceVersion(String identifier, int sequence_version) throws BridgeFailedException {
+        JSONObject jo = (JSONObject) getJsonDataFromWebService(buildJsonQuery(identifier));
+        JSONArray results = (JSONArray) jo.get("results");
+        for (Object result : results) {
+            jo = (JSONObject) result;
+            if (sequence_version == Integer.parseInt(String.valueOf(jo.get("sequenceVersion")))) {
+                String entryVersion = String.valueOf(jo.get("entryVersion"));
+                return getFastaDataFromWebService(buildFastaQuery(identifier, entryVersion));
             }
         }
         return null;
@@ -143,9 +149,11 @@ public class UnisaveClient implements SequenceVersionFetcher{
      * @throws psidev.psi.mi.jami.bridges.exception.BridgeFailedException if any.
      */
     public String getSequenceFor(String identifier, int sequence_version) throws BridgeFailedException{
-        String content = getContentForSequenceVersion(identifier, sequence_version);
-        if (content != null) return getSequence(content);
-        else return null;
+        FastaSequence fastaSequence = getFastaSequenceForSequenceVersion(identifier, sequence_version);
+        if (fastaSequence != null) {
+            return fastaSequence.getSequence();
+        }
+        return null;
     }
 
     /**
@@ -156,12 +164,12 @@ public class UnisaveClient implements SequenceVersionFetcher{
      * @throws psidev.psi.mi.jami.bridges.exception.BridgeFailedException if the identifier cannot be found in UniSave.
      */
     public List<Integer> getVersions( String identifier ) throws BridgeFailedException {
-        JSONArray array = (JSONArray) getDataFromWebService(buildQuery(Type.ENTRIES_INFO, identifier, null));
-        List<Integer> list = new ArrayList<Integer>();
-        JSONObject jo = null;
-        for(int i = 0; i < array.size(); ++i) {
-            jo = (JSONObject) array.get(i);
-            list.add(Integer.valueOf(String.valueOf(jo.get("entry_version"))));
+        JSONObject jo = (JSONObject) getJsonDataFromWebService(buildJsonQuery(identifier));
+        JSONArray results = (JSONArray) jo.get("results");
+        List<Integer> list = new ArrayList<>();
+        for (Object result : results) {
+            jo = (JSONObject) result;
+            list.add(Integer.valueOf(String.valueOf(jo.get("entryVersion"))));
         }
 
         if( list.isEmpty() ) {
@@ -184,16 +192,20 @@ public class UnisaveClient implements SequenceVersionFetcher{
             throw new IllegalArgumentException("The date cannot be null.");
         }
 
-        JSONArray array = (JSONArray) getDataFromWebService(buildQuery(Type.ENTRIES, identifier, null));
-        JSONObject jo = null;
+        JSONObject jo = (JSONObject) getJsonDataFromWebService(buildJsonQuery(identifier));
+        JSONArray results = (JSONArray) jo.get("results");
         DateFormat formatter = new SimpleDateFormat("dd-MMM-yyyy");
-        Date auxDate = null;
-        for(int i = 0; i < array.size(); ++i) {
-            jo = (JSONObject) array.get(i);
+        Date auxDate;
+        for (Object result : results) {
+            jo = (JSONObject) result;
             try {
                 auxDate = formatter.parse((String) jo.get("firstReleaseDate"));
-                if(auxDate.before(date)){
-                    return getSequence(String.valueOf(jo.get("content")));
+                if (auxDate.before(date)) {
+                    String entryVersion = String.valueOf(jo.get("entryVersion"));
+                    FastaSequence fastaSequence = getFastaDataFromWebService(buildFastaQuery(identifier, entryVersion));
+                    if (fastaSequence != null) {
+                        return fastaSequence.getSequence();
+                    }
                 }
             } catch (ParseException e) {
                 e.printStackTrace();
@@ -216,18 +228,22 @@ public class UnisaveClient implements SequenceVersionFetcher{
             throw new IllegalArgumentException("The date cannot be null.");
         }
 
-        Map<Integer, String> oldSequences = new HashMap<Integer, String>();
-        JSONArray array = (JSONArray) getDataFromWebService(buildQuery(Type.ENTRIES, identifier, null));
-        JSONObject jo = null;
+        Map<Integer, String> oldSequences = new HashMap<>();
+        JSONObject jo = (JSONObject) getJsonDataFromWebService(buildJsonQuery(identifier));
+        JSONArray results = (JSONArray) jo.get("results");
         DateFormat formatter = new SimpleDateFormat("dd-MMM-yyyy");
-        Date auxDate = null;
-        for(int i = 0; i < array.size(); ++i){
-            jo = (JSONObject) array.get(i);
+        Date auxDate;
+        for (Object result : results) {
+            jo = (JSONObject) result;
             try {
-                auxDate = formatter.parse((String) jo.get("firstReleaseDate") );
-                if(auxDate.before(date)){
-                    oldSequences.put(Integer.valueOf(String.valueOf(jo.get("sequence_version"))),
-                            getSequence((String) jo.get("content")));
+                auxDate = formatter.parse((String) jo.get("firstReleaseDate"));
+                Integer sequenceVersion = Integer.valueOf(String.valueOf(jo.get("sequenceVersion")));
+                if (auxDate.before(date) && !oldSequences.containsKey(sequenceVersion)) {
+                    String entryVersion = String.valueOf(jo.get("entryVersion"));
+                    FastaSequence fastaSequence = getFastaDataFromWebService(buildFastaQuery(identifier, entryVersion));
+                    if (fastaSequence != null) {
+                        oldSequences.put(sequenceVersion, fastaSequence.getSequence());
+                    }
                 }
             } catch (ParseException e) {
                 e.printStackTrace();
@@ -246,9 +262,7 @@ public class UnisaveClient implements SequenceVersionFetcher{
      * @throws psidev.psi.mi.jami.bridges.exception.BridgeFailedException if the version given doesn't have an entryId that can be found in UniSave.
      */
     public FastaSequence getFastaSequence( String identifier, int version ) throws BridgeFailedException {
-        String content = getContentForSequenceVersion(identifier, version);
-        if (content != null) return new FastaSequence( getFastHeader(content), getSequence(content) );
-        else return null;
+        return getFastaSequenceForSequenceVersion(identifier, version);
     }
 
 
@@ -262,18 +276,24 @@ public class UnisaveClient implements SequenceVersionFetcher{
      * @throws psidev.psi.mi.jami.bridges.exception.BridgeFailedException if any.
      */
     public int getSequenceVersion(String identifier, String sequence) throws BridgeFailedException{
-        JSONArray array = (JSONArray) getDataFromWebService(buildQuery(Type.ENTRIES, identifier, null));
+        JSONObject jo = (JSONObject) getJsonDataFromWebService(buildJsonQuery(identifier));
+        JSONArray results = (JSONArray) jo.get("results");
 
         if ( log.isDebugEnabled() ) {
             log.debug( "Collecting version(s) for entry by ac: " + identifier );
-            log.debug( "Found " + array.size() + " version(s)" );
+            log.debug( "Found " + results.size() + " version(s)" );
         }
-        JSONObject jo = null;
-        for(int i = 0; i < array.size(); ++i){
-            jo = (JSONObject) array.get(i);
-            String content = (String)jo.get("content");
-            if (sequence.equalsIgnoreCase(getSequence(content))){
-                return Integer.valueOf(String.valueOf(jo.get("sequence_version")));
+        Set<Integer> versionsChecked = new HashSet<>();
+        for (Object result : results) {
+            jo = (JSONObject) result;
+            Integer sequenceVersion = Integer.valueOf(String.valueOf(jo.get("sequenceVersion")));
+            if (!versionsChecked.contains(sequenceVersion)) {
+                String entryVersion = String.valueOf(jo.get("entryVersion"));
+                FastaSequence fastaSequence = getFastaDataFromWebService(buildFastaQuery(identifier, entryVersion));
+                if (fastaSequence != null && sequence.equalsIgnoreCase(fastaSequence.getSequence())) {
+                    return sequenceVersion;
+                }
+                versionsChecked.add(sequenceVersion);
             }
         }
         return -1;
@@ -293,43 +313,32 @@ public class UnisaveClient implements SequenceVersionFetcher{
      */
     public List<SequenceVersion> getAvailableSequenceUpdate( String identifier, String sequence ) throws BridgeFailedException {
 
-        LinkedList<SequenceVersion> sequenceUpdates = new LinkedList<SequenceVersion>();
+        LinkedList<SequenceVersion> sequenceUpdates = new LinkedList<>();
 
         // 1. get all versions ordered from the most recent to the oldest
         if ( log.isDebugEnabled() ) {
             log.debug( "Collecting version(s) for entry by  ac: " + identifier );
         }
 
-        JSONArray array = (JSONArray) getDataFromWebService(buildQuery(Type.ENTRIES, identifier, null));
-        JSONObject jo = null;
+        JSONObject jo = (JSONObject) getJsonDataFromWebService(buildJsonQuery(identifier));
+        JSONArray results = (JSONArray) jo.get("results");
         int parameterSequenceVersion = getSequenceVersion(identifier, sequence);
         int currentSequenceVersion = -1;
-        for(int i = 0 ; i < array.size() ; ++i){
-            jo = (JSONObject) array.get(i);
-            if(parameterSequenceVersion < Integer.parseInt(String.valueOf(jo.get("sequence_version")))){
-                if(currentSequenceVersion != Integer.parseInt(String.valueOf(jo.get("sequence_version")))){
+        for (Object result : results) {
+            jo = (JSONObject) result;
+            if (parameterSequenceVersion < Integer.parseInt(String.valueOf(jo.get("sequenceVersion")))) {
+                if (currentSequenceVersion != Integer.parseInt(String.valueOf(jo.get("sequenceVersion")))) {
                     //New version of the sequence
-                    currentSequenceVersion = Integer.parseInt(String.valueOf(jo.get("sequence_version")));
-                    FastaSequence fastaSequence = getFastaSequence(identifier, currentSequenceVersion);
-                    sequenceUpdates.add(new SequenceVersion(fastaSequence, currentSequenceVersion));
+                    currentSequenceVersion = Integer.parseInt(String.valueOf(jo.get("sequenceVersion")));
+                    String entryVersion = String.valueOf(jo.get("entryVersion"));
+                    FastaSequence fastaSequence = getFastaDataFromWebService(buildFastaQuery(identifier, entryVersion));
+                    if (fastaSequence != null) {
+                        sequenceUpdates.add(new SequenceVersion(fastaSequence, currentSequenceVersion));
+                    }
                 }
             }
         }
         return sequenceUpdates;
-    }
-
-    private enum Type {
-        ENTRIES ("/json/entries/"),
-        ENTRY_VERSION ("/json/entry/"),
-        ENTRIES_INFO ("/json/entryinfos/"),
-        ENTRY_INFO_VERSION ("/json/entryinfo/");
-
-        private final String value;
-
-        Type(String value){ this.value = value;}
-
-        private String valueOf(){return this.value;}
-
     }
 
     /** {@inheritDoc} */

--- a/jami-bridges/jami-unisave/src/test/java/psidev/psi/mi/jami/bridges/unisave/UnisaveClientTest.java
+++ b/jami-bridges/jami-unisave/src/test/java/psidev/psi/mi/jami/bridges/unisave/UnisaveClientTest.java
@@ -176,135 +176,7 @@ public class UnisaveClientTest {
         Assert.assertNotNull(sv);
         Assert.assertNotNull(sv.getSequence());
         Assert.assertEquals("MALLHSARVLSGVASAFHPGLAAAASARASSWWAHVEMGPPDPILGVTEAYKRDTNSKKMNLGVGAYRDDNGKPYVLPSVRKAEAQIAAKGLDKEYLPIGGLAEFCRASAELALGENSEVVKSGRFVTVQTISGTGALRIGASFLQRFFKFSRDVFLPKPSWGNHTPIFRDAGMQLQSYRYYDPKTCGFDFTGALEDISKIPEQSVLLLHACAHNPTGVDPRPEQWKEIATVVKKRNLFAFFDMAYQGFASGDGDKDAWAVRHFIEQGINVCLCQSYAKNMGLYGERVGAFTVICKDADEAKRVESQLKILIRPMYSNPPIHGARIASTILTSPDLRKQWLQEVKGMADRIIGMRTQLVSNLKKEGSTHSWQHITDQIGMFCFTGLKPEQVERLTKEFSIYMTKDGRISVAGVTSGNVGYLAHAIHQVTK", sv.getSequence().getSequence());
-        Assert.assertEquals("FT   TRANSIT         1..29\n" +
-                "FT                   /note=\"Mitochondrion\"\n" +
-                "FT                   /evidence=\"ECO:0000269|PubMed:4030726\"\n" +
-                "FT   CHAIN           30..430\n" +
-                "FT                   /note=\"Aspartate aminotransferase, mitochondrial\"\n" +
-                "FT                   /id=\"PRO_0000123886\"\n" +
-                "FT   BINDING         65\n" +
-                "FT                   /ligand=\"substrate\"\n" +
-                "FT                   /evidence=\"ECO:0000250\"\n" +
-                "FT   BINDING         162\n" +
-                "FT                   /ligand=\"substrate\"\n" +
-                "FT                   /evidence=\"ECO:0000250\"\n" +
-                "FT   BINDING         215\n" +
-                "FT                   /ligand=\"substrate\"\n" +
-                "FT                   /evidence=\"ECO:0000250\"\n" +
-                "FT   BINDING         407\n" +
-                "FT                   /ligand=\"substrate\"\n" +
-                "FT                   /evidence=\"ECO:0000250\"\n" +
-                "FT   MOD_RES         48\n" +
-                "FT                   /note=\"Phosphothreonine\"\n" +
-                "FT                   /evidence=\"ECO:0000250|UniProtKB:P00505\"\n" +
-                "FT   MOD_RES         59\n" +
-                "FT                   /note=\"N6-acetyllysine\"\n" +
-                "FT                   /evidence=\"ECO:0000250|UniProtKB:P05202\"\n" +
-                "FT   MOD_RES         73\n" +
-                "FT                   /note=\"N6-acetyllysine; alternate\"\n" +
-                "FT                   /evidence=\"ECO:0000250|UniProtKB:P00505\"\n" +
-                "FT   MOD_RES         73\n" +
-                "FT                   /note=\"N6-succinyllysine; alternate\"\n" +
-                "FT                   /evidence=\"ECO:0000250|UniProtKB:P05202\"\n" +
-                "FT   MOD_RES         82\n" +
-                "FT                   /note=\"N6-acetyllysine\"\n" +
-                "FT                   /evidence=\"ECO:0000250|UniProtKB:P05202\"\n" +
-                "FT   MOD_RES         90\n" +
-                "FT                   /note=\"N6-acetyllysine; alternate\"\n" +
-                "FT                   /evidence=\"ECO:0000250|UniProtKB:P00505\"\n" +
-                "FT   MOD_RES         90\n" +
-                "FT                   /note=\"N6-succinyllysine; alternate\"\n" +
-                "FT                   /evidence=\"ECO:0000250|UniProtKB:P05202\"\n" +
-                "FT   MOD_RES         96\n" +
-                "FT                   /note=\"3'-nitrotyrosine; alternate\"\n" +
-                "FT                   /evidence=\"ECO:0000250|UniProtKB:P05202\"\n" +
-                "FT   MOD_RES         96\n" +
-                "FT                   /note=\"Phosphotyrosine; alternate\"\n" +
-                "FT                   /evidence=\"ECO:0000250|UniProtKB:P00505\"\n" +
-                "FT   MOD_RES         122\n" +
-                "FT                   /note=\"N6-acetyllysine; alternate\"\n" +
-                "FT                   /evidence=\"ECO:0000250|UniProtKB:P05202\"\n" +
-                "FT   MOD_RES         122\n" +
-                "FT                   /note=\"N6-succinyllysine; alternate\"\n" +
-                "FT                   /evidence=\"ECO:0000250|UniProtKB:P05202\"\n" +
-                "FT   MOD_RES         143\n" +
-                "FT                   /note=\"Phosphoserine\"\n" +
-                "FT                   /evidence=\"ECO:0000250|UniProtKB:P00505\"\n" +
-                "FT   MOD_RES         159\n" +
-                "FT                   /note=\"N6-acetyllysine; alternate\"\n" +
-                "FT                   /evidence=\"ECO:0000250|UniProtKB:P00505\"\n" +
-                "FT   MOD_RES         159\n" +
-                "FT                   /note=\"N6-succinyllysine; alternate\"\n" +
-                "FT                   /evidence=\"ECO:0000250|UniProtKB:P05202\"\n" +
-                "FT   MOD_RES         185\n" +
-                "FT                   /note=\"N6-acetyllysine; alternate\"\n" +
-                "FT                   /evidence=\"ECO:0000250|UniProtKB:P05202\"\n" +
-                "FT   MOD_RES         185\n" +
-                "FT                   /note=\"N6-succinyllysine; alternate\"\n" +
-                "FT                   /evidence=\"ECO:0000250|UniProtKB:P05202\"\n" +
-                "FT   MOD_RES         227\n" +
-                "FT                   /note=\"N6-succinyllysine\"\n" +
-                "FT                   /evidence=\"ECO:0000250|UniProtKB:P05202\"\n" +
-                "FT   MOD_RES         234\n" +
-                "FT                   /note=\"N6-acetyllysine\"\n" +
-                "FT                   /evidence=\"ECO:0000250|UniProtKB:P00505\"\n" +
-                "FT   MOD_RES         279\n" +
-                "FT                   /note=\"N6-(pyridoxal phosphate)lysine; alternate\"\n" +
-                "FT                   /evidence=\"ECO:0000250\"\n" +
-                "FT   MOD_RES         279\n" +
-                "FT                   /note=\"N6-acetyllysine; alternate\"\n" +
-                "FT                   /evidence=\"ECO:0000250|UniProtKB:P05202\"\n" +
-                "FT   MOD_RES         296\n" +
-                "FT                   /note=\"N6-acetyllysine; alternate\"\n" +
-                "FT                   /evidence=\"ECO:0000250|UniProtKB:P00505\"\n" +
-                "FT   MOD_RES         296\n" +
-                "FT                   /note=\"N6-succinyllysine; alternate\"\n" +
-                "FT                   /evidence=\"ECO:0000250|UniProtKB:P05202\"\n" +
-                "FT   MOD_RES         302\n" +
-                "FT                   /note=\"N6-acetyllysine\"\n" +
-                "FT                   /evidence=\"ECO:0000250|UniProtKB:P05202\"\n" +
-                "FT   MOD_RES         309\n" +
-                "FT                   /note=\"N6-acetyllysine; alternate\"\n" +
-                "FT                   /evidence=\"ECO:0000250|UniProtKB:P05202\"\n" +
-                "FT   MOD_RES         309\n" +
-                "FT                   /note=\"N6-succinyllysine; alternate\"\n" +
-                "FT                   /evidence=\"ECO:0000250|UniProtKB:P12344\"\n" +
-                "FT   MOD_RES         313\n" +
-                "FT                   /note=\"Asymmetric dimethylarginine\"\n" +
-                "FT                   /evidence=\"ECO:0000250|UniProtKB:P05202\"\n" +
-                "FT   MOD_RES         338\n" +
-                "FT                   /note=\"N6-acetyllysine; alternate\"\n" +
-                "FT                   /evidence=\"ECO:0000250|UniProtKB:P05202\"\n" +
-                "FT   MOD_RES         338\n" +
-                "FT                   /note=\"N6-succinyllysine; alternate\"\n" +
-                "FT                   /evidence=\"ECO:0000250|UniProtKB:P05202\"\n" +
-                "FT   MOD_RES         345\n" +
-                "FT                   /note=\"N6-acetyllysine\"\n" +
-                "FT                   /evidence=\"ECO:0000250|UniProtKB:P05202\"\n" +
-                "FT   MOD_RES         363\n" +
-                "FT                   /note=\"N6-acetyllysine; alternate\"\n" +
-                "FT                   /evidence=\"ECO:0000250|UniProtKB:P05202\"\n" +
-                "FT   MOD_RES         363\n" +
-                "FT                   /note=\"N6-succinyllysine; alternate\"\n" +
-                "FT                   /evidence=\"ECO:0000250|UniProtKB:P05202\"\n" +
-                "FT   MOD_RES         364\n" +
-                "FT                   /note=\"N6-acetyllysine\"\n" +
-                "FT                   /evidence=\"ECO:0000250|UniProtKB:P05202\"\n" +
-                "FT   MOD_RES         387\n" +
-                "FT                   /note=\"N6-acetyllysine\"\n" +
-                "FT                   /evidence=\"ECO:0000250|UniProtKB:P05202\"\n" +
-                "FT   MOD_RES         396\n" +
-                "FT                   /note=\"N6-acetyllysine; alternate\"\n" +
-                "FT                   /evidence=\"ECO:0000250|UniProtKB:P00505\"\n" +
-                "FT   MOD_RES         396\n" +
-                "FT                   /note=\"N6-succinyllysine; alternate\"\n" +
-                "FT                   /evidence=\"ECO:0000250|UniProtKB:P05202\"\n" +
-                "FT   MOD_RES         404\n" +
-                "FT                   /note=\"N6-acetyllysine; alternate\"\n" +
-                "FT                   /evidence=\"ECO:0000250|UniProtKB:P00505\"\n" +
-                "FT   MOD_RES         404\n" +
-                "FT                   /note=\"N6-succinyllysine; alternate\"\n" +
-                "FT                   /evidence=\"ECO:0000250|UniProtKB:P05202\"", sv.getSequence().getHeader());
+        Assert.assertEquals("sp|P12345|AATM_RABIT Aspartate aminotransferase, mitochondrial OS=Oryctolagus cuniculus OX=9986 GN=GOT2 PE=1 SV=2", sv.getSequence().getHeader());
         Assert.assertEquals(2, sv.getVersion());
     }
 
@@ -324,15 +196,14 @@ public class UnisaveClientTest {
         Assert.assertNotNull(sv);
         Assert.assertNotNull(sv.getSequence());
         Assert.assertEquals("VPFLSKAVRCGPVIPFVIHHFNFRRVTTTKRRRNKYVLVPGYGWVLQDDYLVNSVKMTGENDLPPNQLPHDDDLLFTYAKILLYDYISYFPKFRHNNPDLLDHKTELELFPLKADSAARNKANFYARTLWNDTITDKSAFKPGTYNDTVAGLLLWQQCALMWSLPKSVINRTISGVCDALTNRTSLTLLKRISDWLKQLGLACSPIHRLFIELPTLLGRGAIPGDADKDIKHRLAFDPSITVDVPKEQLHLLIYRLLSRNLNITKVNSFEHHLEERLLWSKSGSHYYPDDKINELLPPQPTRKEFLDVVTTEYIKECKPQVFIRQSRKLEHGKERFIYNCDTVSYVYFDFILKLFETGWQDSEAILSPGDYTSERLHAKISSYKYKAMLDYTDFNSQHTIQSMRLIFETMKELLPPEATFALDWCIASFDNMQTSDGLKWMATLPSGHRATTFINTVLNWCYTQMVGLKFDSFMCAGDDVILMSQQPISLAPILTSHFKFNPSKQSTGTRGEFLRKHYSEAGVFAYPCRAIASLVSGNWLSQSLRENTPILVPIQNGIDRLRSRAGLLGVPWKLGLSELIEREAIPKEVGMALLNSHAAGPGLITRDYSSFTVTPKPPKLSSTLEYTATRYGLQDLSKHVPWKQLTTVESDKLSRQIKKISYRHCSQAKITYNCTYEVFKPRGLPTVLSGSSQPSLSMLWWQAMLKQAIQDDSTKKIDARMFAANACTSSVSGDAFLRANASMAGVLITSLITSSS", sv.getSequence().getSequence());
-        Assert.assertEquals("FT   NON_TER         1\n" +
-                "FT                   /evidence=\"ECO:0000313|EMBL:AAC55469.2\"", sv.getSequence().getHeader());
+        Assert.assertEquals("tr|Q98753|Release 2024_02/2024_02|27-Mar-2024", sv.getSequence().getHeader());
         Assert.assertEquals(2, sv.getVersion());
 
         sv = updateIterator.next();
         Assert.assertNotNull(sv);
         Assert.assertNotNull(sv.getSequence());
         Assert.assertEquals("XPFLSKAVRCGPVIPFVIHHFNFRRVTTTKRRRNKYVLVPGYGWVLQDDYLVNSVKMTGENDLPPNQLPHDDDLLFTYAKILLYDYISYFPKFRHNNPDLLDHKTELELFPLKADSAARNKANFYARTLWNDTITDKSAFKPGTYNDTVAGLLLWQQCALMWSLPKSVINRTISGVCDALTNRTSLTLLKRISDWLKQLGLACSPIHRLFIELPTLLGRGAIPGDADKDIKHRLAFDPSITVDVPKEQLHLLIYRLLSRNLNITKVNSFEHHLEERLLWSKSGSHYYPDDKINELLPPQPTRKEFLDVVTTEYIKECKPQVFIRQSRKLEHGKERFIYNCDTVSYVYFDFILKLFETGWQDSEAILSPGDYTSERLHAKISSYKYKAMLDYTDFNSQHTIQSMRLIFETMKELLPPEATFALDWCIASFDNMQTSDGLKWMATLPSGHRATTFINTVLNWCYTQMVGLKFDSFMCAGDDVILMSQQPISLAPILTSHFKFNPSKQSTGTRGEFLRKHYSEAGVFAYPCRAIASLVSGNWLSQSLRENTPILVPIQNGIDRLRSRAGLLGVPWKLGLSELIEREAIPKEVGMALLNSHAAGPGLITRDYSSFTVTPKPPKLSSTLEYTATRYGLQDLSKHVPWKQLTTVESDKLSRQIKKISYRHCSQAKITYNCTYEVFKPRGLPTVLSGSSQPSLSMLWWQAMLKQAIQDDSTKKIDARMFAANACTSSVSGDAFLRANASMAGVLITSLITSSS", sv.getSequence().getSequence());
-        Assert.assertEquals(null, sv.getSequence().getHeader());
+        Assert.assertEquals("tr|Q98753|Release 13|01-May-2000", sv.getSequence().getHeader());
         Assert.assertEquals(1, sv.getVersion());
 
     }

--- a/jami-bridges/pom.xml
+++ b/jami-bridges/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>psidev.psi.mi.jami</groupId>
         <artifactId>psi-jami</artifactId>
-        <version>3.5.1-SNAPSHOT</version>
+        <version>3.5.2-SNAPSHOT</version>
     </parent>
 
     <groupId>psidev.psi.mi.jami.bridges</groupId>

--- a/jami-commons/pom.xml
+++ b/jami-commons/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>psidev.psi.mi.jami</groupId>
         <artifactId>psi-jami</artifactId>
-        <version>3.5.1-SNAPSHOT</version>
+        <version>3.5.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>jami-commons</artifactId>

--- a/jami-core/pom.xml
+++ b/jami-core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>psidev.psi.mi.jami</groupId>
         <artifactId>psi-jami</artifactId>
-        <version>3.5.1-SNAPSHOT</version>
+        <version>3.5.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>jami-core</artifactId>

--- a/jami-core/src/main/java/psidev/psi/mi/jami/utils/ComplexUtils.java
+++ b/jami-core/src/main/java/psidev/psi/mi/jami/utils/ComplexUtils.java
@@ -77,27 +77,24 @@ public class ComplexUtils {
         if (parentParticipant.getInteractor() instanceof Complex) {
             Complex complex = (Complex) parentParticipant.getInteractor();
             for (ModelledParticipant complexParticipant : complex.getParticipants()) {
-
-                // expand stoichiometry
-                int minStoichiometry = 0;
-                int maxStoichiometry = 0;
-                Stoichiometry expandedStoichiometry = null;
-                if (complexParticipant.getStoichiometry() != null && parentParticipant.getStoichiometry() != null) {
-                    minStoichiometry = (complexParticipant.getStoichiometry().getMinValue())
-                            *
-                            (parentParticipant.getStoichiometry().getMinValue());
-                    maxStoichiometry = (complexParticipant.getStoichiometry().getMaxValue())
-                            *
-                            (parentParticipant.getStoichiometry().getMaxValue());
-                    Class stoichiometryClass = complexParticipant.getStoichiometry().getClass();
-                    try {
-                        expandedStoichiometry = (Stoichiometry) stoichiometryClass.getConstructor(Integer.TYPE, Integer.TYPE).newInstance(minStoichiometry, maxStoichiometry);
-                    } catch (Exception e) {
-                        e.printStackTrace();
+                expandComplexIntoParticipants(complexParticipant).forEach(participant -> {
+                    // expand stoichiometry
+                    int minStoichiometry = 0;
+                    int maxStoichiometry = 0;
+                    Stoichiometry expandedStoichiometry = null;
+                    if (participant.getStoichiometry() != null && parentParticipant.getStoichiometry() != null) {
+                        minStoichiometry = participant.getStoichiometry().getMinValue() * parentParticipant.getStoichiometry().getMinValue();
+                        maxStoichiometry = participant.getStoichiometry().getMaxValue() * parentParticipant.getStoichiometry().getMaxValue();
+                        Class stoichiometryClass = participant.getStoichiometry().getClass();
+                        try {
+                            expandedStoichiometry = (Stoichiometry) stoichiometryClass.getConstructor(Integer.TYPE, Integer.TYPE).newInstance(minStoichiometry, maxStoichiometry);
+                        } catch (Exception e) {
+                            e.printStackTrace();
+                        }
                     }
-                }
-                DefaultModelledParticipant defaultModelledParticipant=new DefaultModelledParticipant(complexParticipant.getInteractor(),expandedStoichiometry);
-                expandedModelledParticipants.add(defaultModelledParticipant);
+                    DefaultModelledParticipant defaultModelledParticipant = new DefaultModelledParticipant(participant.getInteractor(),expandedStoichiometry);
+                    expandedModelledParticipants.add(defaultModelledParticipant);
+                });
             }
             return expandedModelledParticipants;
         }

--- a/jami-core/src/test/java/psidev/psi/mi/jami/utils/ComplexUtilsTest.java
+++ b/jami-core/src/test/java/psidev/psi/mi/jami/utils/ComplexUtilsTest.java
@@ -113,6 +113,61 @@ public class ComplexUtilsTest {
     }
 
     @Test
+    public void test_expand_complex_with_multiple_levels_of_subcomplexes() {
+        // Sub-Sub-Complex-1
+        Complex subSubComplex1 = new DefaultComplex("sub-sub-complex-1", new DefaultCvTerm("protein complex"));
+        subSubComplex1.setInteractionType(new DefaultCvTerm("phosphorylation"));
+        subSubComplex1.addParticipant(new DefaultModelledParticipant(new DefaultProtein("test2 protein",
+                XrefUtils.createUniprotIdentity("P12345")), new DefaultStoichiometry(1, 3)));
+
+        // Sub-Sub-Complex-2
+        Complex subSubComplex2 = new DefaultComplex("sub-sub-complex-2", new DefaultCvTerm("protein complex"));
+        subSubComplex2.setInteractionType(new DefaultCvTerm("phosphorylation"));
+        subSubComplex2.addParticipant(new DefaultModelledParticipant(new DefaultProtein("test2 protein",
+                XrefUtils.createUniprotIdentity("P12346"))));
+
+        // Sub-Complex
+        Complex subComplex = new DefaultComplex("sub-complex", new DefaultCvTerm("protein complex"));
+        subComplex.setInteractionType(new DefaultCvTerm("phosphorylation"));
+        subComplex.addParticipant(new DefaultModelledParticipant(new DefaultProtein("test2 protein",
+                XrefUtils.createUniprotIdentity("P12347")), new DefaultStoichiometry(2, 3)));
+        subComplex.addParticipant(new DefaultModelledParticipant(subSubComplex1, new DefaultStoichiometry(1, 2)));
+        subComplex.addParticipant(new DefaultModelledParticipant(subSubComplex2, new DefaultStoichiometry(1, 2)));
+
+        // Complex
+        Complex complex = new DefaultComplex("complex", new DefaultCvTerm("protein complex"));
+        complex.setInteractionType(new DefaultCvTerm("phosphorylation"));
+        complex.addParticipant(new DefaultModelledParticipant(new DefaultProtein("test2 protein",
+                XrefUtils.createUniprotIdentity("P12348"))));
+        complex.addParticipant(new DefaultModelledParticipant(subComplex, new DefaultStoichiometry(2, 2)));
+
+        ModelledParticipant complexAsParticipant = new DefaultModelledParticipant(complex, new DefaultStoichiometry(1, 1));
+
+        Collection<ModelledParticipant> expandedParticipants = ComplexUtils.expandComplexIntoParticipants(complexAsParticipant);
+        Assert.assertEquals(4, expandedParticipants.size());
+
+        for (ModelledParticipant expandedParticipant : expandedParticipants) {
+            if (expandedParticipant.getInteractor().getPreferredIdentifier().getId().equals("P12345")) {
+                Assert.assertEquals(2, expandedParticipant.getStoichiometry().getMinValue());
+                Assert.assertEquals(12, expandedParticipant.getStoichiometry().getMaxValue());
+                Assert.assertEquals(0, expandedParticipant.getFeatures().size());
+            } else if (expandedParticipant.getInteractor().getPreferredIdentifier().getId().equals("P12346")) {
+                Assert.assertNull(expandedParticipant.getStoichiometry());
+                Assert.assertNull(expandedParticipant.getStoichiometry());
+                Assert.assertEquals(0, expandedParticipant.getFeatures().size());
+            } else if (expandedParticipant.getInteractor().getPreferredIdentifier().getId().equals("P12347")) {
+                Assert.assertEquals(4, expandedParticipant.getStoichiometry().getMinValue());
+                Assert.assertEquals(6, expandedParticipant.getStoichiometry().getMaxValue());
+                Assert.assertEquals(0, expandedParticipant.getFeatures().size());
+            } else if (expandedParticipant.getInteractor().getPreferredIdentifier().getId().equals("P12348")) {
+                Assert.assertNull(expandedParticipant.getStoichiometry());
+                Assert.assertNull(expandedParticipant.getStoichiometry());
+                Assert.assertEquals(0, expandedParticipant.getFeatures().size());
+            }
+        }
+    }
+
+    @Test
     public void testMaintainProteinComparableParticipantMap() {
         ModelledParticipant modelledParticipant1 = new DefaultModelledParticipant(new DefaultProtein("test1 protein",
                 XrefUtils.createUniprotIdentity("UNIPROTID1")), new DefaultStoichiometry(1, 3));

--- a/jami-core/src/test/java/psidev/psi/mi/jami/utils/comparator/participant/CollectionComparatorTest.java
+++ b/jami-core/src/test/java/psidev/psi/mi/jami/utils/comparator/participant/CollectionComparatorTest.java
@@ -167,4 +167,52 @@ public class CollectionComparatorTest {
         Assert.assertTrue(collectionComparator.compare(complex1.getComparableParticipants(), complex2.getComparableParticipants()) == -1);
         Assert.assertTrue(collectionComparator.compare(complex2.getComparableParticipants(), complex1.getComparableParticipants()) == 1);
     }
+
+    @Test
+    public void test_complex_with_sub_sub_complexes(){
+        //complex1
+        Complex subSubComplex1 = new DefaultComplex("CPX-5692", new DefaultCvTerm("protein complex"));
+        subSubComplex1.setInteractionType(new DefaultCvTerm("phosphorylation"));
+        subSubComplex1.addParticipant(new DefaultModelledParticipant(new DefaultProtein("test protein",
+                XrefUtils.createUniprotIdentity("P0DTD1-PRO_0000449628"))));
+        subSubComplex1.addParticipant(new DefaultModelledParticipant(new DefaultProtein("test protein",
+                XrefUtils.createUniprotIdentity("P0DTD1-PRO_0000449631"))));
+
+        Complex subSubComplex2 = new DefaultComplex("CPX-6442", new DefaultCvTerm("protein complex"));
+        subSubComplex2.setInteractionType(new DefaultCvTerm("phosphorylation"));
+        subSubComplex2.addParticipant(new DefaultModelledParticipant(new DefaultProtein("test protein",
+                XrefUtils.createUniprotIdentity("P0DTD1-PRO_0000449625")), new DefaultStoichiometry(1, 1)));
+        subSubComplex2.addParticipant(new DefaultModelledParticipant(new DefaultProtein("test protein",
+                XrefUtils.createUniprotIdentity("P0DTD1-PRO_0000449626")), new DefaultStoichiometry(1, 1)));
+        subSubComplex2.addParticipant(new DefaultModelledParticipant(new DefaultProtein("test protein",
+                XrefUtils.createUniprotIdentity("P0DTD1-PRO_0000449626")), new DefaultStoichiometry(1, 1)));
+        subSubComplex2.addParticipant(new DefaultModelledParticipant(new DefaultProtein("test protein",
+                XrefUtils.createUniprotIdentity("P0DTD1-PRO_0000449629")), new DefaultStoichiometry(1, 1)));
+        subSubComplex2.addParticipant(new DefaultModelledParticipant(new DefaultProtein("test protein",
+                XrefUtils.createUniprotIdentity("P0DTD1-PRO_0000449630")), new DefaultStoichiometry(1, 1)));
+        subSubComplex2.addParticipant(new DefaultModelledParticipant(new DefaultProtein("test protein",
+                XrefUtils.createUniprotIdentity("P0DTD1-PRO_0000449630")), new DefaultStoichiometry(1, 1)));
+
+        Complex subComplex = new DefaultComplex("CPX-7041", new DefaultCvTerm("protein complex"));
+        subComplex.setInteractionType(new DefaultCvTerm("phosphorylation"));
+        subComplex.addParticipant(new DefaultModelledParticipant(new DefaultProtein("test protein",
+                XrefUtils.createUniprotIdentity("P0DTD1-PRO_0000449627")), new DefaultStoichiometry(1, 1)));
+        subComplex.addParticipant(new DefaultModelledParticipant(subSubComplex1, new DefaultStoichiometry(1, 1)));
+        subComplex.addParticipant(new DefaultModelledParticipant(subSubComplex2, new DefaultStoichiometry(1, 1)));
+
+        Complex complex1 = new DefaultComplex("CPX-7083", new DefaultCvTerm("protein complex"));
+        complex1.setInteractionType(new DefaultCvTerm("phosphorylation"));
+        complex1.addParticipant(new DefaultModelledParticipant(subComplex, new DefaultStoichiometry(1, 1)));
+        complex1.addParticipant(new DefaultModelledParticipant(subComplex, new DefaultStoichiometry(1, 1)));
+
+        //complex2
+        Complex complex2 = new DefaultComplex("CPX-5687", new DefaultCvTerm("protein complex"));
+        complex2.setInteractionType(new DefaultCvTerm("phosphorylation"));
+        complex2.addParticipant(new DefaultModelledParticipant(new DefaultProtein("test protein",
+                XrefUtils.createUniprotIdentity("P0DTD1-PRO_0000449627")), new DefaultStoichiometry(1, 1)));
+        complex2.addParticipant(new DefaultModelledParticipant(new DefaultProtein("test protein",
+                XrefUtils.createUniprotIdentity("P0DTD1-PRO_0000449627")), new DefaultStoichiometry(1, 1)));
+
+        Assert.assertNotEquals(0, collectionComparator.compare(complex1.getComparableParticipants(), complex2.getComparableParticipants()));
+    }
 }

--- a/jami-crosslink-csv/pom.xml
+++ b/jami-crosslink-csv/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>psidev.psi.mi.jami</groupId>
         <artifactId>psi-jami</artifactId>
-        <version>3.5.1-SNAPSHOT</version>
+        <version>3.5.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>jami-crosslink-csv</artifactId>

--- a/jami-enricher/pom.xml
+++ b/jami-enricher/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>psidev.psi.mi.jami</groupId>
         <artifactId>psi-jami</artifactId>
-        <version>3.5.1-SNAPSHOT</version>
+        <version>3.5.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>jami-enricher</artifactId>

--- a/jami-examples/pom.xml
+++ b/jami-examples/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>psidev.psi.mi.jami</groupId>
         <artifactId>psi-jami</artifactId>
-        <version>3.5.1-SNAPSHOT</version>
+        <version>3.5.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>jami-examples</artifactId>

--- a/jami-html/pom.xml
+++ b/jami-html/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>psidev.psi.mi.jami</groupId>
         <artifactId>psi-jami</artifactId>
-        <version>3.5.1-SNAPSHOT</version>
+        <version>3.5.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>jami-html</artifactId>

--- a/jami-imex-updater/pom.xml
+++ b/jami-imex-updater/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>psidev.psi.mi.jami</groupId>
         <artifactId>psi-jami</artifactId>
-        <version>3.5.1-SNAPSHOT</version>
+        <version>3.5.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>jami-imex-updater</artifactId>

--- a/jami-interactionviewer-json/pom.xml
+++ b/jami-interactionviewer-json/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>psidev.psi.mi.jami</groupId>
         <artifactId>psi-jami</artifactId>
-        <version>3.5.1-SNAPSHOT</version>
+        <version>3.5.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>jami-interactionviewer-json</artifactId>

--- a/jami-mitab/pom.xml
+++ b/jami-mitab/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>psidev.psi.mi.jami</groupId>
         <artifactId>psi-jami</artifactId>
-        <version>3.5.1-SNAPSHOT</version>
+        <version>3.5.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>jami-mitab</artifactId>

--- a/jami-xml/pom.xml
+++ b/jami-xml/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>psidev.psi.mi.jami</groupId>
         <artifactId>psi-jami</artifactId>
-        <version>3.5.1-SNAPSHOT</version>
+        <version>3.5.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>jami-xml</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>psidev.psi.mi.jami</groupId>
     <artifactId>psi-jami</artifactId>
-    <version>3.5.1-SNAPSHOT</version>
+    <version>3.5.2-SNAPSHOT</version>
 
     <packaging>pom</packaging>
     <name>PSI :: JAMI - Java framework for molecular interactions</name>
@@ -15,7 +15,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <spring.version>4.3.30.RELEASE</spring.version>
 
-        <ontology.manager.version>2.1.2-SNAPSHOT</ontology.manager.version>
+        <ontology.manager.version>2.1.2</ontology.manager.version>
         <ols.client.version>2.14-SNAPSHOT</ols.client.version>
         <uniprot.japi.version>1.1.2</uniprot.japi.version>
         <chebiws.client.version>2.4</chebiws.client.version>


### PR DESCRIPTION
There are 2 fixes in this PR:
- Calls to `http://www.ebi.ac.uk/uniprot/unisave/rest` are failing, so we're replacing them with calls to `https://rest.uniprot.org/unisave`.
- Method to expand complex participants and find duplicates is not recursive, so it ignores subcomplexes of subcomplexes. Adding recursion to fix this issue.